### PR TITLE
Add and update Rubies as necessary.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: ruby
 before_install: gem install bundler
 rvm:
+  - 2.2.0
+  - 2.1.5
   - 2.0.0
   - 1.9.3
   - 1.9.2
-  - jruby-1.7.3
+  - jruby-1.7.19


### PR DESCRIPTION
`pessimize` looks compatible with the latest Rubies and JRubies. Let's make it official! These changes pass on Travis, with the exception of JRuby which I think is not properly configured on my fork.

- Ruby 2.1 and Ruby 2.2 builds.
- Update JRuby version.