### PR TITLE
Leave pessimistic gem versions alone, no matter the requested constraint

### DIFF
--- a/lib/pessimize/version_mapper.rb
+++ b/lib/pessimize/version_mapper.rb
@@ -3,8 +3,12 @@ module Pessimize
     def call(gems, versions, version_constraint)
       gems.each do |gem|
         if versions.has_key? gem.name
-          version_parts = versions[gem.name].split('.')
-          version = version_constraint == 'minor' ? version_parts.first(2).join('.') : version_parts.join('.')
+          version = versions[gem.name]
+          if !::Gem::Version.new(version).prerelease?
+            version_parts = versions[gem.name].split('.')
+            version_parts = version_constraint == 'minor' ? version_parts.first(2) : version_parts
+            version = version_parts.join('.')
+          end
           gem.version = "~> #{version}"
         end
       end

--- a/spec/version_mapper_spec.rb
+++ b/spec/version_mapper_spec.rb
@@ -24,6 +24,20 @@ module Pessimize
       its(:version) { should == '~> 2.2' }
     end
 
+    context "with a gem, version hash with prerelease version, and minor constraint" do
+      let(:gems)     { [ gem('example') ] }
+      let(:versions) { { 'example' => '2.2.3.rc1' } }
+      let(:mapper)   { VersionMapper.new }
+
+      before do
+        mapper.call gems, versions, 'minor'
+      end
+
+      subject { gems.first }
+
+      its(:version) { should == '~> 2.2.3.rc1' }
+    end
+
     context "with multiple gems, version hash and minor constraint" do
       let(:gems)     { [ gem('example'), gem('fish', '1.3.2') ] }
       let(:versions) { { 'example' => '1.4.9', 'fish' => '2.3.0' } }
@@ -80,6 +94,20 @@ module Pessimize
 
         its(:version) { should == '~> 2.3.0' }
       end
+    end
+
+    context "with a gem, version hash with prerelease version, and patch constraint" do
+      let(:gems)     { [ gem('example') ] }
+      let(:versions) { { 'example' => '2.2.3.rc1' } }
+      let(:mapper)   { VersionMapper.new }
+
+      before do
+        mapper.call gems, versions, 'patch'
+      end
+
+      subject { gems.first }
+
+      its(:version) { should == '~> 2.2.3.rc1' }
     end
   end
 end


### PR DESCRIPTION
When I ran `pessimize` on a Gemfile containing prerelease gem versions they got stripped out and later calls to `bundle` would fail. This attempts to leave those versions alone while still converting to a pessimistic constraint so later gem updates are picked up.
