### PR TITLE
Replace deprecated trollop gem with optimist

### DIFF
--- a/lib/pessimize/shell.rb
+++ b/lib/pessimize/shell.rb
@@ -1,6 +1,6 @@
 require 'pessimize/file_manager'
 require 'pessimize/pessimizer'
-require 'trollop'
+require 'optimist'
 
 module Pessimize
   class Shell
@@ -23,7 +23,7 @@ module Pessimize
     end
 
     def cli_options
-      Trollop::options do
+      Optimist::options do
         version "pessimize #{VERSION} (c) #{Time.now.year} Jon Cairns"
         banner <<-EOS
 Usage: pessimize [options]
@@ -43,7 +43,7 @@ Options:
     def check_options!(options)
       constraints = %w(minor patch)
       unless constraints.include? options[:version_constraint]
-        Trollop::die :version_constraint, "must be one of #{constraints.join("|")}"
+        Optimist::die :version_constraint, "must be one of #{constraints.join("|")}"
       end
     end
 

--- a/pessimize.gemspec
+++ b/pessimize.gemspec
@@ -15,7 +15,7 @@ This is for people who work with projects that use bundler, such as rails projec
   gem.homepage      = "https://github.com/joonty/pessimize"
 
   gem.add_dependency 'bundler'
-  gem.add_dependency 'trollop'
+  gem.add_dependency 'optimist'
   gem.add_development_dependency 'rspec', '~> 2.13.0'
   gem.add_development_dependency 'rake', '~> 10.0.3'
   gem.add_development_dependency 'codeclimate-test-reporter', '~> 0.6.0'

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -567,7 +567,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     json (1.8.0)
-    optimist (3.0.0)
+    optimist (3.0.1)
     sqlite3 (1.3.7)
     EOD
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -561,13 +561,13 @@ GIT
   specs:
     pessimize (0.2.0)
       bundler
-      trollop
+      optimist
 
 GEM
   remote: https://rubygems.org/
   specs:
     json (1.8.0)
-    trollop (2.1.2)
+    optimist (3.0.0)
     sqlite3 (1.3.7)
     EOD
 


### PR DESCRIPTION
`trollop` has been renamed to `optimist`.  

This PR gets rid of the an ugly deprecation warning when running pessimize --

`[DEPRECATION] This gem has been renamed to optimist and will no longer be supported. Please switch to optimist as soon as possible.` 

For Reference: The trollop rename PR can be found here: https://github.com/ManageIQ/optimist/pull/99