### PR TITLE
Remove inappropriate language from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Anyone who works with a Gemfile, i.e. a project that uses [bundler][1].
 
 ### What does it do?
-Pessimize adds version numbers with the pessimistic constraint operator (`~>`, a.k.a. "spermy" operator) to all gems in your `Gemfile`.
+Pessimize adds version numbers with the pessimistic constraint operator (`~>`) to all gems in your `Gemfile`.
 
 ### Why?
 You should be using `~> x.x` to limit the version numbers of your gems, otherwise `bundle update` could potentially break your application. Read the section on "why bundle update can be dangerous" for a more detailed description, or take a look at the [rubygems explanation][2].


### PR DESCRIPTION
Hi,

Thank you for making the `pessimize` gem available. I was one of the early advocates for using it and even presented it at the Montreal Ruby meetup group back in 2014 or so.

In any case, I was about to recommend it to my new software engineering team when I noticed an inappropriate word in the README documentation that bars this gem from being used at work.

I removed it as it is unnecessary let alone neither Ruby idiomatic nor mentioned at the [Bundler docs about versioning](https://guides.rubygems.org/patterns/#pessimistic-version-constraint).

Cheers!

Andy Maleh