### PR TITLE
Ruby 3.2 support: Fix File.exists? call to File.exist?

### DIFF
--- a/lib/pessimize/file_manager.rb
+++ b/lib/pessimize/file_manager.rb
@@ -9,7 +9,7 @@ module Pessimize
     end
 
     def gemfile?
-      File.exists? gemfile
+      File.exist? gemfile
     end
 
     def gemfile_contents
@@ -17,7 +17,7 @@ module Pessimize
     end
 
     def gemfile_lock?
-      File.exists? gemfile_lock
+      File.exist? gemfile_lock
     end
 
     def backup_gemfile!

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -25,7 +25,7 @@ describe "running pessimize" do
 
       context "the Gemfile.backup" do
         it "should be created" do
-          File.exists?(tmp_path + 'Gemfile.backup').should be_true
+          File.exist?(tmp_path + 'Gemfile.backup').should be_true
         end
 
         it "should be the same as the original Gemfile" do
@@ -63,13 +63,13 @@ describe "running pessimize" do
 
       context "the Gemfile.backup" do
         it "should not exist" do
-          File.exists?(tmp_path + 'Gemfile.backup').should be_false
+          File.exist?(tmp_path + 'Gemfile.backup').should be_false
         end
       end
 
       context "the Gemfile.lock.backup" do
         it "should not exist" do
-          File.exists?(tmp_path + 'Gemfile.lock.backup').should be_false
+          File.exist?(tmp_path + 'Gemfile.lock.backup').should be_false
         end
       end
 


### PR DESCRIPTION
This fixes Ruby 3.2 support where `File.exists?` has been removed - it was deprecated in Ruby 2.5.

Tests still passed in Ruby 3.1 and 2.7